### PR TITLE
Add schema generation test.

### DIFF
--- a/tests/test_generate_schema.py
+++ b/tests/test_generate_schema.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import List
+
+from pydiggy import Node, reverse
+
+def test_generate_schema():
+    class Map(Node):
+        pass
+
+    class Region(Node):
+        map: 'Map' = reverse(name="territories", many=True)
+        name: str
+        borders: List['Region']
+
+    schema, unknown = Node._generate_schema()
+
+    expected = """Map: bool @index(bool) .
+Region: bool @index(bool) .
+_type: string .
+name: string .
+uid: int ."""
+
+    assert schema == expected


### PR DESCRIPTION
I added a test that passes on what was unexpected behavior for me. Note that the "expected" value does not include the 'map' predicate or its reversal. 